### PR TITLE
Graceful Error Handling - Update code example

### DIFF
--- a/lessons.yaml
+++ b/lessons.yaml
@@ -3091,7 +3091,7 @@ pages:
         ```
         match do_something_that_might_fail() {
           Ok(v) => v,
-          Err(e) => { return e; },
+          Err(e) => e,
         }
         ```
 
@@ -3108,7 +3108,7 @@ pages:
         ```
         match do_something_that_might_fail() {
           Ok(v) => v,
-          Err(e) => { return e; },
+          Err(e) => e,
         }
         ```
     pt-br:
@@ -3124,7 +3124,7 @@ pages:
         ```
         match do_something_that_might_fail() {
           Ok(v) => v,
-          Err(e) => { return e; },
+          Err(e) => e,
         }
         ```
 
@@ -3142,7 +3142,7 @@ pages:
         ```
         match do_something_that_might_fail() {
           Ok(v) => v,
-          Err(e) => { return e; },
+          Err(e) => e,
         }
         ```
 


### PR DESCRIPTION
I feel like it's confusing to the reader that one of the match arm explicitly returns while the other one doesn't