### PR TITLE
[FR] Correction of WASM Chapter 1 & beginning of 2

### DIFF
--- a/wasm.yaml
+++ b/wasm.yaml
@@ -22,8 +22,8 @@ common_words:
     next: Suivant
     previous: Précédant
     toc: Table des Matières
-    lessons: Lessons
-    untranslated: Untranslated
+    lessons: Leçons
+    untranslated: Non traduit
   fr_c:
     chapter: Chapitre
     tor: Tour de WebAssembly
@@ -115,8 +115,8 @@ pages:
       content_markdown: |
         Bienvenue au * Tour de WebAssembly *. Celui-ci a pour but d'être une introduction à la technologie
         et comment Rust peut être utilisé pour alimenter le Web. Si tu n'es pas à l'aise avec Rust,
-        je te conseille le [Tour de Rust] (https://tourofrust.com/)! La plupart de nos exemples seront
-        suffisamment simple pour pouvoir être suivie par n'importe qui, même les débutants.
+        je te conseilles le [Tour de Rust] (https://tourofrust.com/)! La plupart de nos exemples seront
+        suffisamment simples pour pouvoir être suivis par n'importe qui, même les débutants.
         Cette visite est également disponible en C.
 
         * [Rust (english)] (index.html)
@@ -127,9 +127,9 @@ pages:
         * [C (français)] (index_fr_c.html)
 
         Si tu as des suggestions sur le contenu ou souhaite contribuer aux traductions,
-        consultez le [dépôt github] du Tour de WebAssembly (https://github.com/richardanaya/tour_of_rust).
+        consultes le [dépôt github](https://github.com/richardanaya/tour_of_rust) du Tour de WebAssembly.
 
-        Tu peux parcourir la visite avec le clavier <span class="emoji">⬅️</span> et <span class="emoji">➡️</span>
+        Tu peux parcourir la visite avec les touches <span class="emoji">⬅️</span> et <span class="emoji">➡️</span> du clavier.
     fr_c:
       title: Salut, WebAssembly
       content_markdown: |
@@ -144,9 +144,9 @@ pages:
         * [C (français)] (index_fr_c.html)
 
         Si tu as des suggestions sur le contenu ou souhaite contribuer aux traductions,
-        consultez le [dépôt github] du Tour de WebAssembly (https://github.com/richardanaya/tour_of_rust).
+        consultes le [dépôt github](https://github.com/richardanaya/tour_of_rust) du Tour de WebAssembly.
 
-        Tu peux parcourir la visite avec le clavier <span class="emoji">⬅️</span> et <span class="emoji">➡️</span>
+        Tu peux parcourir la visite avec les touches <span class="emoji">⬅️</span> et <span class="emoji">➡️</span> du clavier.
     ie:
       title: Salute, WebAssembly
       content_markdown: |
@@ -204,14 +204,14 @@ pages:
       clone: en
       
     fr:
-      title: Chapter 1 - Qu'est-ce que WebAssembly?
+      title: Chapitre 1 - Qu'est-ce que WebAssembly?
       content_markdown: |
         WebAssembly est un format binaire pour représenter un code exécutable dans
         un environement isolé. Il a été développé pour être exécuté par les navigateurs
         web et propose une alternative au langage Javascript avec plusieurs avantages
         distincts:
 
-        * Etant du bytecode de bas niveau, cela permet d'effectuer des calculs
+        * Étant du bytecode de bas niveau, cela permet d'effectuer des calculs
         plus rapidement que le JavaScript et d'avoir plus de contrôle sur la gestion
         de la mémoire.
         * WebAssembly a été créé en s'inspirant des compilateurs existants, permettant
@@ -221,7 +221,7 @@ pages:
         * WebAssembly a été construit indépendamment de l'hôte, rendant possible
         son utilisation [en dehors des navigateurs](https://wasmer.io/)!
  
-        WebAssembly est souvent racourcie en ** WASM **.
+        WebAssembly est souvent racourci en ** WASM **.
     fr_c:
       clone: fr
       
@@ -266,17 +266,17 @@ pages:
     en_c:
       clone: en
     fr:
-      title: A l'Intérieur d'un Module
+      title: À l'Intérieur d'un Module
       content_markdown: |
-        Lorsque tu compile vers du bytecode WebAssembly, le compilateur
-        créer un fichier `.wasm` qu'on appele un **module**.
+        Lorsque tu compiles vers du bytecode WebAssembly, le compilateur
+        crée un fichier `.wasm` qu'on appele un **module**.
 
         Un module est un [format binaire](https://webassembly.github.io/spec/core/index.html)
         contenant des informations sur le programme wasm et sur la mémoire qu'il
         utilise. Un module contient:
         * une liste de fonctions
         * quelles fonctions doivent être exportées/importées
-        * quelles données doivent se trouvées initialement dans la mémoire des modules wasm
+        * quelles données doivent se trouver initialement dans la mémoire des modules wasm
     fr_c:
       clone: fr
     ie:
@@ -359,7 +359,7 @@ pages:
     fr:
       title: Créer d'un Module
       content_markdown: |
-        Les modules sont crées à partir d'octets.
+        Les modules sont créés à partir d'octets.
 
         ```
         let module = await WebAssembly.instantiate(bytes);
@@ -408,7 +408,7 @@ pages:
       title: Utiliser un Module
       content_markdown: |
         Un module peut **exporter** une ou plusieurs fonctions qui
-        seront utilisable par le code JavaScript. Typiquement
+        seront utilisables par le code JavaScript. Typiquement
         il existe une fonction à appeler pour démarrer
         un programme wasm (par exemple `main`,` start`).
 
@@ -497,11 +497,11 @@ pages:
     en_c:
       clone: en
     fr:
-      title: Chapitre 1 Conclusion
+      title: Chapitre 1 - Conclusion
       content_markdown: |
         J'espère t'avoir convaincu que, fondamentalement, WebAssembly
         n'est pas si compliqué que ça! Dans notre prochain chapitre, nous allons
-        commencez à examiner en détail comment JavaScript et WebAssembly peuvent
+        commencer à examiner en détail comment JavaScript et WebAssembly peuvent
         échanger des données.
     fr_c:
       clone: fr
@@ -519,7 +519,7 @@ pages:
     en_c:
       clone: en
     fr:
-      title: Chapter 2 - Partage de structures de données
+      title: Chapitre 2 - Partage de structures de données
       content_markdown: |
         JavaScript et ton programme WebAssembly ont des représentations très différentes des données au niveau de la mémoire.
         Pour rendre les choses plus complexes, l'interaction avec l'environnement hôte de WebAssembly est très limité.
@@ -555,7 +555,7 @@ pages:
       content_markdown: |
         Les modules WebAssembly ne peuvent appeler que des fonctions JavaScript qui ont été explicitement importées.
 
-        Rust utilise `extern" C "{...}` pour répertorier les signatures de fonction de ces fonctions importées.
+        Rust utilise `extern" C "{...}` pour répertorier les signatures des fonctions importées.
 
         Note que l'appel d'une fonction importée est considéré comme `unsafe` (dangereux) par Rust car le compilateur
         ne peut faire aucune garantie sur ce qui se passe dans son implémentation.
@@ -703,16 +703,16 @@ pages:
 
         `` `JavaScript
         // Crée un tableau de 8 octets.
-        let bytes = new ArrayBuffer (8);
+        let bytes = new ArrayBuffer(8);
         // Affiche ces 8 octets comme des entiers non signés 8 bits.
-        let u8_bytes = new Uint8Array (bytes);
-        // Modifie le tampon du tableau.
-        u8_bytes [0] = 16; // 00010000
-        u8_bytes [1] = 1; // 00000001
+        let u8_bytes = new Uint8Array(bytes);
+        // Modification du tableau d'octets.
+        u8_bytes[0] = 16; // 00010000
+        u8_bytes[1] = 1; // 00000001
         // Réinterprète les bytes u8_bytes de l'ArrayBuffer comme
         // des entiers signés 32 bits petits-boutiste (little endian).
-        let i32_bytes = new Int32Array (u8_bytes.buffer);
-        console.log (i32_bytes [0]);
+        let i32_bytes = new Int32Array(u8_bytes.buffer);
+        console.log(i32_bytes[0]);
         /// 272 ou 00010000000000010000000000000000
         ```
     fr_c:
@@ -840,15 +840,15 @@ pages:
       clone: en
       code: https://webassembly.studio/?embed&f=vh15t7nok4p
     fr:
-      title: Logging Text
+      title: Logger du texte
       code: https://webassembly.studio/?embed&f=1gxcr004p3x
       content_markdown: |
         Explorons un exemple simple d'affichage de texte à partir d'un programme WebAssembly.
 
         Nous devons:
-        1. Créez du texte compatible utf-8 dans la mémoire de notre programme.
-        2. Déterminez la longueur des octets de notre texte.
-        3. Envoyez d'une manière ou d'une autre l'index de début du premier octet
+        1. Créer du texte compatible utf-8 dans la mémoire de notre programme.
+        2. Déterminer la longueur des octets de notre texte.
+        3. Envoyer d'une manière ou d'une autre l'index de début du premier octet
         et la longueur en octets du texte au navigateur hôte afin qu'il
         puisse appeler `console.log`.
 


### PR DESCRIPTION
Corrected Grammar, typos and other issues on the French translation of WASM tour.

Note : Github's editor has added a newline at the end of the file.