### PR TITLE
Add additional explanation for the code sample

### DIFF
--- a/lessons.yaml
+++ b/lessons.yaml
@@ -4927,6 +4927,14 @@ pages:
         The generic function `parse` can be used to convert strings 
         or string literals into a typed value. This function returns 
         a `Result` because it could fail.
+        
+        Here, as before, Main returns `Result` with no value or an error. 
+        But, this time error type is defined using Traits: 
+        `Box<dyn std::error::Error>`.
+        This allows us to define all possible error types into a single type, 
+        instead of maintaining a complex structure of all possible 
+        statically-known error combinations. More About Traits, later.
+        
       code: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20-%3E%20Result%3C()%2C%20Box%3Cdyn%20std%3A%3Aerror%3A%3AError%3E%3E%20%7B%0A%20%20%20%20let%20a%20%3D%2042%3B%0A%20%20%20%20let%20a_string%20%3D%20a.to_string()%3B%0A%20%20%20%20let%20b%20%3D%20a_string.parse%3A%3A%3Ci32%3E()%3F%3B%0A%20%20%20%20println!(%22%7B%7D%20%7B%7D%22%2C%20a%2C%20b)%3B%0A%20%20%20%20Ok(())%0A%7D%0A
 
     fr:


### PR DESCRIPTION
Hi! very nice job, really enjoy following through...

So... the page "Converting Strings" has this code as example:

`fn main() -> Result<(), Box<dyn std::error::Error>> {
    let a = 42;
    let a_string = a.to_string();
    let b = a_string.parse::<i32>()?;
    println!("{} {}", a, b);
    Ok(())
}
`

and, it is the first time that new concepts (Box, Trait (and syntax 'dyn Trait')) are introduced in the code sample but not explained on the left side...  This PR extends the existing text a bit to give more context.