### PR TITLE
[EN] split Module Hierarchy page

### DIFF
--- a/lessons.yaml
+++ b/lessons.yaml
@@ -6646,7 +6646,7 @@ pages:
 
         Every crate has a root module.
 
-        A module holds global variables, functions, structs, traits, and other modules!
+        A module can holds global variables, functions, structs, traits or even other modules!
         
     ie:
       title: Modules
@@ -6711,32 +6711,48 @@ pages:
         Ferris ne manja TAU, solmen PI.
         
   - en:
-      title: Module Heirarchy
+      title: Creating Modules
       content_markdown: |
-        When we think of code, we usually imagine a heirarchy of files organized in directories. 
+        When we think of code, we usually imagine a hierarchy of files organized
+        in directories. Rust let you create modules closely related to your file
+        structure.
         
-        Rust can have a module `foo` represented as:
+        There are two ways in Rust to declare a module. For example, a module
+        `foo` can be represented as:
           * a file named `foo.rs`
           * a directory named `foo` with a file `mod.rs` inside
-
-        In order to establish a relationship between a module and it's sub-module, you must write in the parent module:
+        
+    ie:
+      title:  Creation de un Modul
+        Quande on pensa pri code, on imagina por li pluparte un hierarchie de archives organisat in archivieres.
+        Rust let you create modules closely related to your file
+        structure.
+        
+        There are two ways in Rust to declare a module. Rust posse posseder un modul `foo` representat quam
+          * un archive nominat `foo.rs`
+          * un archiviere nominat `foo` in quel sta un archive `mod.rs`
+        
+  - en:
+      title: Module Hierarchy
+      content_markdown: |
+        A module can depends on another one. In order to establish a relationship
+        between a module and it's sub-module, you must write in the parent module:
 
         ```rust
+        // This declaration will look for a file named `foo.rs` or `foo/mod.rs` and
+        // will insert its contents inside a module named `foo` under this scope
         mod foo;
         ```
         
     ie:
       title: Hierarchie de un Modul
-        Quande on pensa pri code, on imagina por li pluparte un hierarchie de archives organisat in archivieres.
-        
-        Rust posse posseder un modul `foo` representat quam
-          * un archive nominat `foo.rs`
-          * un archiviere nominat `foo` in quel sta un archive `mod.rs`
-        Por etablisser un relation inter un model e su sub-modul, on deve scrir quam seque in li modul genitori.
+      A module can depends on another one. Por etablisser un relation inter un model e su sub-modul, on deve scrir quam seque in li modul genitori.
         ```rust
+        // This declaration will look for a file named `foo.rs` or `foo/mod.rs` and
+        // will insert its contents inside a module named `foo` under this scope
         mod foo;
-        ```
-        
+      ```
+
   - en:
       title: Inline Module
       content_markdown: |


### PR DESCRIPTION
I feel it makes more sense if we split the Module Hierarchy page and create a Creating Modules page.

I also made some small changes in the phrasing.

Can you check if you like it?

I updated the interlingue version but it still in English and need proper translation.