### PR TITLE
Update German translation

### DIFF
--- a/lessons.yaml
+++ b/lessons.yaml
@@ -21,7 +21,7 @@ common_words:
     welcometothe: "Bienvenue au"
     presstocontinue: "Clique pour continuer"
   de:
-    tor: Tour zu Rust
+    tor: Tour durch Rust
     next: Weiter
     previous: Zurück
     toc: Inhaltsverzeichnis


### PR DESCRIPTION
"Tour zu Rust" implies a tour that leads towards Rust. "Tour durch Rust" is a tour through something as is a tour _through_ a museum.