### PR TITLE
Add German translation for arrays chapter

### DIFF
--- a/lessons.yaml
+++ b/lessons.yaml
@@ -1046,7 +1046,11 @@ pages:
     de:
       title: Arrays
       content_markdown: |
-        Need translation
+        Ein *Array* ist eine Kollektion Datenelementen vom selben Datentyp mit festgelegter Länge.
+
+        Der Datentyp eines *Arrays* wird `[T;N]` geschrieben. `T` ist der Datentyp der Arrayelemente und `N` ist die festgelegte Länge dieser zur Compile-Zeit.
+
+        Einzelne Elemente können mit dem `[x]` Operator abgerufen werden, in welchem *x* den *usize* Index (beginnend bei 0) des gesuchten Elementes darstellt.
     ie:
       title: Arrays
       content_markdown: |

--- a/lessons.yaml
+++ b/lessons.yaml
@@ -1046,7 +1046,7 @@ pages:
     de:
       title: Arrays
       content_markdown: |
-        Ein *Array* ist eine Kollektion Datenelementen vom selben Datentyp mit festgelegter Länge.
+        Ein *Array* ist eine Kollektion von Datenelementen vom selben Datentyp mit festgelegter Länge.
 
         Der Datentyp eines *Arrays* wird `[T;N]` geschrieben. `T` ist der Datentyp der Arrayelemente und `N` ist die festgelegte Länge dieser zur Compile-Zeit.
 


### PR DESCRIPTION
As promised the Arrays chapter translation 😊 !

Is the html in part of the translations a remnant of older versions or does it serve a specific reason? Otherwise I would fix that for German.