### PR TITLE
[JA] Fix typo

### DIFF
--- a/lessons/ja/chapter_3.yaml
+++ b/lessons/ja/chapter_3.yaml
@@ -93,7 +93,7 @@
 
     その他の事情:
     * Rust の `列挙` は *tagged-union* とも言われています。
-    * 複数の型を組み合わせて新しい型を作ることができます。 これが Rust には *algebrai types* を持つと言われる理由です。
+    * 複数の型を組み合わせて新しい型を作ることができます。 これが Rust には *algebraic types* を持つと言われる理由です。
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=90e4fe63a23ebaa82574d1beef55b41e
 - title: 第三章 - まとめ


### PR DESCRIPTION
I found a typo in `ja/chapter_3.yaml`. Fixed it.