### PR TITLE
[wasm] Fix broken top links

### DIFF
--- a/wasm/en/chapter_0.yaml
+++ b/wasm/en/chapter_0.yaml
@@ -12,21 +12,19 @@
     enough to follow along by anyone though. This tour is also available in C.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [C (english)] (00_en_c.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     If you have suggestions on content or would like to contribute to

--- a/wasm/en_c/chapter_0.yaml
+++ b/wasm/en_c/chapter_0.yaml
@@ -6,21 +6,19 @@
     and how C can be used to power the web. This tour is also available in Rust.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     If you have suggestions on content or would like to contribute to

--- a/wasm/es/chapter_0.yaml
+++ b/wasm/es/chapter_0.yaml
@@ -12,21 +12,19 @@
     suficientemente fáciles para cualquier persona que quiera seguirlos.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [C (english)] (00_en_c.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     En el caso de que tengas sugerencias respecto al contenido o quieras

--- a/wasm/fr/chapter_0.yaml
+++ b/wasm/fr/chapter_0.yaml
@@ -15,21 +15,19 @@
     Cette visite est également disponible en C.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [C (english)] (00_en_c.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     Si tu as des suggestions sur le contenu ou souhaite contribuer aux

--- a/wasm/fr_c/chapter_0.yaml
+++ b/wasm/fr_c/chapter_0.yaml
@@ -7,21 +7,19 @@
     également disponible en Rust.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (english)] (00_en_c.html)
 
 
     Si tu as des suggestions sur le contenu ou souhaite contribuer aux

--- a/wasm/ie/chapter_0.yaml
+++ b/wasm/ie/chapter_0.yaml
@@ -12,21 +12,19 @@
     a sequer por quicunc. Li tur es anc disponibil in C.
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (日本語)] (00_ja.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [C (english)] (00_en_c.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     Si tu have suggestiones pri contenete o vole contribuer al traductiones,

--- a/wasm/ja/chapter_0.yaml
+++ b/wasm/ja/chapter_0.yaml
@@ -8,21 +8,19 @@
     このツアーはCでも利用可能です。
 
 
-    * [Rust (english)] (index.html)
+    * [Rust (english)] (00_en.html)
 
-    * [Rust (français)] (index_fr.html)
+    * [Rust (français)] (00_fr.html)
 
-    * [Rust (Interlingue)] (index_ie.html)
+    * [Rust (Interlingue)] (00_ie.html)
 
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
+    * [Rust (Português Brasileiro)] (00_pt-br.html)
 
-    * [Rust (Español)] (index_es.html)
+    * [Rust (Español)] (00_es.html)
 
-    * [Rust (日本語)] (index_ja.html)
+    * [C (english)] (00_en_c.html)
 
-    * [C (english)] (index_en_c.html)
-
-    * [C (français)] (index_fr_c.html)
+    * [C (français)] (00_fr_c.html)
 
 
     コンテンツへの提案や翻訳に貢献したい場合、

--- a/wasm/pt-br/chapter_0.yaml
+++ b/wasm/pt-br/chapter_0.yaml
@@ -2,14 +2,21 @@
   content_markdown: >
     Bem-vindo ao *Tour por WebAssembly*. Pretendemos ser uma introdução a esta tecnologia e de como o Rust pode ser usado para dar mais força à web. Se você é completamente novo no Rust pode apreciar o [Tour por Rust](https://tourofrust.com/)! A maioria dos nossos exemplos será fácil o suficiente para qualquer pessoa acompanhar. Este tour também está disponível para a linguagem C.
 
-    * [Rust (english)] (index.html)
-    * [Rust (français)] (index_fr.html)
-    * [Rust (Interlingue)] (index_ie.html)
-    * [Rust (Português Brasileiro)] (index_pt-br.html)
-    * [Rust (Español)] (index_es.html)
-    * [Rust (日本語)] (index_ja.html)
-    * [C (english)] (index_en_c.html)
-    * [C (français)] (index_fr_c.html)
+
+    * [Rust (english)] (00_en.html)
+
+    * [Rust (français)] (00_fr.html)
+
+    * [Rust (Interlingue)] (00_ie.html)
+
+    * [Rust (Español)] (00_es.html)
+
+    * [Rust (日本語)] (00_ja.html)
+
+    * [C (english)] (00_en_c.html)
+
+    * [C (français)] (00_fr_c.html)
+
 
     Caso tenha alguma sugestão a respeito do conteúdo ou queira contribuir com as traduções, veja o repositório do Tour do WebAssembly [github repository](https://github.com/richardanaya/tour_of_rust).
 


### PR DESCRIPTION
In `wasm/${lang}/chapter_0.yml`, links for other languages should point to `00_${lang}.html`.

But for now it points to `index_${lang}.html` and becomes 404. 😿 

This PR fixes it and also follows Tour of Rust's manner(which makes current lang not to be listed).