### PR TITLE
Some love for 0

### DIFF
--- a/lessons/en/chapter_1.yaml
+++ b/lessons/en/chapter_1.yaml
@@ -71,10 +71,9 @@
     * booleans - `bool` for representing true/false
 
     * unsigned integers - `u8` `u16` `u32` `u64` `u128` for representing
-    positive whole numbers
+    nonnegative whole numbers
 
-    * signed integers - `i8` `i16` `i32` `i64` `i128` for representing
-    positive/negative whole numbers
+    * signed integers - `i8` `i16` `i32` `i64` `i128` for representing whole numbers
 
     * pointer sized integers - `usize` `isize` for representing indexes
 

--- a/lessons/hu/chapter_1.yaml
+++ b/lessons/hu/chapter_1.yaml
@@ -81,11 +81,10 @@
 
     * boolean - `bool` igaz és hamis értékekhez
 
-    * előjel nélküli egészek - `u8` `u16` `u32` `u64` `u128` pozitív egész
+    * előjel nélküli egészek - `u8` `u16` `u32` `u64` `u128` nemnegatív egész
     számok kifejezésére
 
-    * előjeles egészek - `i8` `i16` `i32` `i64` `i128` pozitív és negatív egész
-    számok kifejezésére
+    * előjeles egészek - `i8` `i16` `i32` `i64` `i128` egész számok kifejezésére
 
     * mutató méretű egészek - `usize` `isize` tömbök indexeinek és a memóriában
     tárolt dolgok méretének tárolására


### PR DESCRIPTION
Technically speaking, the terms "positive" and "negative" integers exclude zero. While nonnegative is a bit less friendly, it is the correct term to describe unsigned integers.