### PR TITLE
Fix Markdown of the rust data types

### DIFF
--- a/lessons/es/chapter_1.yaml
+++ b/lessons/es/chapter_1.yaml
@@ -61,15 +61,15 @@
 
     * booleanos - `bool` para representar verdadero/falso.
     
-    * números enteros sin signo - `u8``u32``u64``u128` para representar números enteros positivos.
+    * números enteros sin signo - `u8` `u32` `u64` `u128` para representar números enteros positivos.
     
-    * números enteros con signo - `i8``i32``i64``i128` para representar números enteros positivos y negativos.
+    * números enteros con signo - `i8` `i32` `i64` `i128` para representar números enteros positivos y negativos.
     
-    * números enteros de tamaño de puntero - `usize``isize` se usan para representar índices y tamaños de elementos en memoria.
+    * números enteros de tamaño de puntero - `usize` `isize` se usan para representar índices y tamaños de elementos en memoria.
     
-    * números en coma flotante - `f32``f64`.
+    * números en coma flotante - `f32` `f64`.
     
-    * En relación a textos - `str``char`.
+    * En relación a textos - `str` `char`.
     
     * tuplas - `(valor,valor,...)` para pasar secuencias fijas de valores en la pila.
     


### PR DESCRIPTION
There was a little typo of the markdown on the Spanish version

![image](https://user-images.githubusercontent.com/15748455/98859939-ed1c0a00-2430-11eb-8f15-73584b8c1890.png)

https://tourofrust.com/05_es.html
