### PR TITLE
Marking all portuguese translations as complete

### DIFF
--- a/lessons/README.md
+++ b/lessons/README.md
@@ -13,7 +13,7 @@ Every time you finish the translation of a chapter update the table underneath.
 |ie    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓  |
 |ja    | ✓ | ✓ | ✓ | ✓ |   |   |   |   |   |   | ✓  |
 |ko    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓  |
-|pt-br | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓  |
+|pt-br | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓  |
 |ru    | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓  |
 |zh-cn | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   | ✓ | ✓  |
 |zh-tw | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   |    |


### PR DESCRIPTION
After #370, I took a better look into the missing  Brazilian Portuguese translation chapters.

|Chapter| 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|------|---|---|---|---|---|---|---|---|---|---|----|
|pt-br | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |   |   |   | ✓  |

I checked the chapters (I'm also a native pt-br speaker :D), and it looks pretty complete to me (and very well translated! All thanks to @Denstone).

@Denstone, can you confirm if this is correct?