### PR TITLE
chore: add hint about dynamic arrays

### DIFF
--- a/lessons/en/chapter_1.yaml
+++ b/lessons/en/chapter_1.yaml
@@ -136,7 +136,7 @@
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20let%20nums%3A%20%5Bi32%3B%203%5D%20%3D%20%5B1%2C%202%2C%203%5D%3B%0A%20%20%20%20println!(%22%7B%3A%3F%7D%22%2C%20nums)%3B%0A%20%20%20%20println!(%22%7B%7D%22%2C%20nums%5B1%5D)%3B%0A%7D%0A
   content_markdown: >
-    An *array* is a fixed length collection of data elements all of the same
+    An *array* is a **fixed length collection** of data elements all of the same
     type.
 
 
@@ -146,6 +146,10 @@
 
     Individual elements can be retrieved with the `[x]` operator where *x* is a
     *usize* index (starting at 0) of the element you want.
+
+
+    Collections with a dynamic length, often called dynamic or variable arrays, are
+    introduced in a later chapter about **Vectors**.
 - title: Functions
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20add(x%3A%20i32%2C%20y%3A%20i32)%20-%3E%20i32%20%7B%0A%20%20%20%20return%20x%20%2B%20y%3B%0A%7D%0A%0Afn%20main()%20%7B%0A%20%20%20%20println!(%22%7B%7D%22%2C%20add(42%2C%2013))%3B%0A%7D%0A


### PR DESCRIPTION
Since some programming languages only know dynamic arrays (e. g. JS or PHP), I think it's important to highlight the distinction.