### PR TITLE
chore: remove double if/else in title

### DIFF
--- a/lessons/en/chapter_2.yaml
+++ b/lessons/en/chapter_2.yaml
@@ -6,7 +6,7 @@
     maybe
 
     enjoy a surprise or two.
-- title: if/else if/else
+- title: if/else
   content_markdown: >
     Code branching in Rust is not surprising.
 


### PR DESCRIPTION
I'm not sure if it's intentional or not, but it's probably confusing if there is 2x if/else in the title.