### PR TITLE
Added padding in code block to make '_' visible

### DIFF
--- a/docs/tour.css
+++ b/docs/tour.css
@@ -92,8 +92,8 @@ code {
   color: white;
   padding-left: 5px;
   padding-right: 5px;
+  padding-bottom: 3px;
   margin-right: 3px;
-
   margin-left: 3px;
 }
 


### PR DESCRIPTION
Signed-off-by: Soumya Ghosh Dastidar <gdsoumya@gmail.com>

I was going through the rust tour and found that the underscores(`_`) are not visible in the code blocks, that caused some confusion for me in some places. I found a quick fix to add a little padding to the code blocks which makes the underscores visible. I have attached the screenshots for reference.
-  Before
![before](https://user-images.githubusercontent.com/44349253/118802385-af0c1100-b8bf-11eb-8ffc-0a48899929bb.png)
- After
![after](https://user-images.githubusercontent.com/44349253/118802399-b3382e80-b8bf-11eb-9f40-d1b0ba2e20ef.png)
