### PR TITLE
Fix: issues in chapters 1 and 4 of the pt_br translation

### DIFF
--- a/lessons/pt-br/chapter_1.yaml
+++ b/lessons/pt-br/chapter_1.yaml
@@ -4,7 +4,7 @@
 
 
     E se por acaso você está se perguntando quem é este adorável caranguejo falante, eu me chamo **Ferris** e sou o mascote não oficial da linguagem de programação Rust. Prazer em conhecê-lo.
-- title: O Playgroung do Rust
+- title: O Playground do Rust
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20println!(%22Bem-vindo%20%C3%A0%20%C3%A1rea%20de%20testes!%20Voc%C3%AA%20pode%20modificar%20seu%20c%C3%B3digo%20aqui.%22)%3B%0A%7D%0A
   content_markdown: >
@@ -69,33 +69,33 @@
     * `str` (string slice) - texto com comprimento conhecido em tempo de execução
 
 
-    Textos podem ser mais complexos do que você está acostumado com outras linguagens. Uma vez que o Rust é uma linguagem de programação de sistemas, ele cuida do gerenciamento de memória de uma maneira que pode não estar familiarizado. Entraremos em detalhes mais adiante.
+    Formatos de texto podem ser mais complexos do que você está acostumado com outras linguagens. Uma vez que o Rust é uma linguagem de programação de sistemas, ele cuida do gerenciamento de memória de uma maneira que pode não estar familiarizado. Entraremos em detalhes mais adiante.
 
 
     Tipos numéricos podem ser especificados explicitamente adicionando o tipo ao final do número (por exemplo: `13u32`, `2u8`)
 - title: Conversão de tipos básica
   content_markdown: >
-    O Rust requer que sejamos explícitos quando se trata de tipos numéricos. Não podemos usar um `u8` quando precisamos usar um `u32` sem que se produza um erro.
+    O Rust requer que sejamos explícitos quando se trata de tipos numéricos. Não podemos usar um `u8` como um `u32` sem que se produza um erro.
 
 
-    Por sorte o Rust faz com que as conversões de tipos numéricos sejam muito simples usando a plavra-chave **as**.
+    Por sorte, o Rust faz com que as conversões de tipos numéricos sejam muito simples usando a plavra-chave **as**.
 - title: Constantes
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=const%20PI%3A%20f32%20%3D%203.14159%3B%0A%0Afn%20main()%20%7B%0A%20%20%20%20println!(%0A%20%20%20%20%20%20%20%20%22Para%20fazer%20uma%20%7B%7Dzza%2C%20voc%C3%AA%20deve%20primeiro%20criar%20o%20Universo.%22%2C%0A%20%20%20%20%20%20%20%20PI%0A%20%20%20%20)%3B%0A%7D%0A
   content_markdown: >
-    As constantes nos permitem especificar um valor comum que pode ser usado muitas vezes por todos o nosso código de maneira eficiente. Ao invés de copiar os valores como variáveis onde serão utilizadas, as constantes substituirão o identificador de texto pelo seu valor onde quer que estejam sendo usadas em tempo de compilação.
+    As constantes nos permitem especificar um valor comum que pode ser usado muitas vezes por todo o nosso código de maneira eficiente. Ao invés de copiar os valores como variáveis onde serão utilizadas, as constantes substituirão o identificador de texto pelo seu valor onde quer que estejam sendo usadas em tempo de compilação.
 
 
-    Diferentemente das variáveis, o tipo das constantes devem ter sempre declarados.
+    Diferentemente das variáveis, o tipo das constantes devem ser sempre declarados.
 
 
     Os nomes das constantes são sempre em `SCREAMING_SNAKE_CASE`.
-- title: Matrizes
+- title: Arrays
   content_markdown: >
-    Uma *matriz* é uma coleção de elementos de tamanho fixo todos os seu valores do mesmo tipo.
+    Uma *array* é uma *coleção de tamanho fixo* de elementos, todos os seu valores são do mesmo tipo.
 
 
-    O tipo de dado para uma *matriz* é `[T;N]`, onde T é o tipo dos valores e N é o comprimento fixo conhecido em tempo de compilação.
+    O tipo de dado para uma *array* é `[T;N]`, onde T é o tipo dos valores e N é o comprimento fixo conhecido em tempo de compilação.
 
 
     Os elementos podem ser recuperados individualmente com o operador `[x]`, onde *x* é o índice do tipo *usize* (começando de 0) do elemento que deseja recuperar.

--- a/lessons/pt-br/chapter_1.yaml
+++ b/lessons/pt-br/chapter_1.yaml
@@ -92,7 +92,7 @@
     Os nomes das constantes são sempre em `SCREAMING_SNAKE_CASE`.
 - title: Arrays
   content_markdown: >
-    Uma *array* é uma *coleção de tamanho fixo* de elementos, todos os seu valores são do mesmo tipo.
+    Uma *array* é uma *coleção de tamanho fixo* de elementos, cujos valores são todos do mesmo tipo.
 
 
     O tipo de dado para uma *array* é `[T;N]`, onde T é o tipo dos valores e N é o comprimento fixo conhecido em tempo de compilação.

--- a/lessons/pt-br/chapter_4.yaml
+++ b/lessons/pt-br/chapter_4.yaml
@@ -142,15 +142,15 @@
     Seja um bom rustáceo e use `match` apropriadamente quando puder!
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20faz_alguma_coisa_que_pode_falhar(i%3A%20i32)%20-%3E%20Result%3Cf32%2C%20String%3E%20%7B%0A%20%20%20%20if%20i%20%3D%3D%2042%20%7B%0A%20%20%20%20%20%20%20%20Ok(13.0)%0A%20%20%20%20%7D%20else%20%7B%0A%20%20%20%20%20%20%20%20Err(String%3A%3Afrom(%22este%20n%C3%A3o%20%C3%A9%20o%20n%C3%BAmero%20correto%22))%20%20%20%0A%20%20%20%20%7D%0A%7D%0A%0Afn%20main()%20-%3E%20Result%3C()%2C%20String%3E%20%7B%0A%20%20%20%20%2F%2F%20conciso%2C%20mas%20pretencioso%20e%20falha%20r%C3%A1pido%0A%20%20%20%20let%20v%20%3D%20faz_alguma_coisa_que_pode_falhar(42).unwrap()%3B%0A%20%20%20%20println!(%22encontrei%20%7B%7D%22%2C%20v)%3B%0A%20%20%20%20%0A%20%20%20%20%2F%2F%20erro%20de%20panic!%0A%20%20%20%20let%20v%20%3D%20faz_alguma_coisa_que_pode_falhar(1).unwrap()%3B%0A%20%20%20%20println!(%22encontrei%20%7B%7D%22%2C%20v)%3B%0A%20%20%20%20%0A%20%20%20%20Ok(())%0A%7D%0A
-- title: Matrizes
+- title: Vetores
   content_markdown: >
-    Alguns dos tipos genéricos mais úteis são os tipos de coleção. Uma matriz é uma lista de itens de tamanho variável representada pela estrutura `Vec`.
+    Alguns dos tipos genéricos mais úteis são os tipos de coleção. Um vetor é uma lista de itens de tamanho variável representada pela estrutura `Vec`.
 
 
-    A macro `vec!` nos permite criar facilmente uma matriz ao invés de contruir uma manualmente.
+    A macro `vec!` nos permite criar facilmente um ao invés de contruir uma manualmente.
 
 
-    `Vec` possui o método `iter()` o qual cria um iterador a partir de uma matriz, permitindo-nos facilmente usr uma matriz em um loop `for`.
+    `Vec` possui o método `iter()` o qual cria um iterador a partir de uma matriz, permitindo-nos facilmente usar um vetor em um loop `for`.
 
 
     Detalhes da Memória:
@@ -158,7 +158,7 @@
 
     * `Vec` é um struct, mas internamente contém uma referência a uma lista fixa de seus itens no heap.
 
-    * Uma matriz começa com uma capacidade padrão. Quando são adicionados mais itens do que a capacidade inicial, ele realoca seus dados no heap para ter uma nova lista fixa com capacidade maior.
+    * Um vetor começa com uma capacidade padrão. Quando são adicionados mais itens do que a capacidade inicial, ele realoca seus dados no heap para ter uma nova lista fixa com capacidade maior.
   code: >-
     https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20%2F%2F%20Podemos%20ser%20expl%C3%ADcitos%20com%20o%20tipo%0A%20%20%20%20let%20mut%20i32_vec%20%3D%20Vec%3A%3A%3Ci32%3E%3A%3Anew()%3B%20%2F%2F%20turbofish%20%3C3%0A%20%20%20%20i32_vec.push(1)%3B%0A%20%20%20%20i32_vec.push(2)%3B%0A%20%20%20%20i32_vec.push(3)%3B%0A%0A%20%20%20%20%2F%2F%20Veja%20qu%C3%A3o%20esperto%20o%20Rust%20%C3%A9%20determinando%20o%20tipo%20automaticamente%0A%20%20%20%20let%20mut%20float_vec%20%3D%20Vec%3A%3Anew()%3B%0A%20%20%20%20float_vec.push(1.3)%3B%0A%20%20%20%20float_vec.push(2.3)%3B%0A%20%20%20%20float_vec.push(3.4)%3B%0A%0A%20%20%20%20%2F%2F%20Olha%20que%20macro%20linda!%0A%20%20%20%20let%20string_vec%20%3D%20vec!%5BString%3A%3Afrom(%22Ol%C3%A1%22)%2C%20String%3A%3Afrom(%22Mundo%22)%5D%3B%0A%0A%20%20%20%20for%20word%20in%20string_vec.iter()%20%7B%0A%20%20%20%20%20%20%20%20println!(%22%7B%7D%22%2C%20word)%3B%0A%20%20%20%20%7D%0A%7D%0A
 - title: Capítulo 4 - Conclusão


### PR DESCRIPTION
This merge:
- Fixes some typos and grammar issues
- Renames ***Matrizes*** to ***Arrays***, it is better to leave this untranslated.
  - In brazilian portuguese, and in the programming context, the word ***matrizes*** is commonly referred only to two-dimensional arrays and up.
  - The widely used MDN documentation (for JS) also choses to [not translate the term](https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array).