### PR TITLE
Corrects grammar and punctuation erros of lesson 1 in german language.

### DIFF
--- a/lessons/de/chapter_1.yaml
+++ b/lessons/de/chapter_1.yaml
@@ -168,7 +168,7 @@
     Funktionsnamen sollten im `snake_case` Format vergeben werden.
 
 
-    Hinweis: wenn man eine Funktion deklariert, dann spricht man bei den Daten,
+    Hinweis: Wenn man eine Funktion deklariert, dann spricht man bei den Daten,
     die die Funktion aktzeptiert, von Parametern. Ruft man die Funktion dann auf und
     übergibt ihr Daten, dann spricht man von Argumenten.
 - title: Mehrere return-Variablen

--- a/lessons/de/chapter_1.yaml
+++ b/lessons/de/chapter_1.yaml
@@ -169,7 +169,7 @@
 
 
     Hinweis: wenn man eine Funktion deklariert, dann spricht man bei den Daten,
-    die die Funktion aktzeptiert von Parametern. Ruft man die Funktion dann auf und
+    die die Funktion aktzeptiert, von Parametern. Ruft man die Funktion dann auf und
     übergibt ihr Daten, dann spricht man von Argumenten.
 - title: Mehrere return-Variablen
   content_markdown: >

--- a/lessons/de/chapter_1.yaml
+++ b/lessons/de/chapter_1.yaml
@@ -168,7 +168,7 @@
     Funktionsnamen sollten im `snake_case` Format vergeben werden.
 
 
-    Hinweis: wenn man eine Funktion deklariert, dann sind spricht man bei den Daten,
+    Hinweis: wenn man eine Funktion deklariert, dann spricht man bei den Daten,
     die die Funktion aktzeptiert von Parametern. Ruft man die Funktion dann auf und
     übergibt ihr Daten, dann spricht man von Argumenten.
 - title: Mehrere return-Variablen


### PR DESCRIPTION
While doing the tour of rust in German, I noticed grammar and punctuation  errors. This PR contains the fixes.