### PR TITLE
Added `char` explanation and code example

### DIFF
--- a/lessons/en/chapter_1.yaml
+++ b/lessons/en/chapter_1.yaml
@@ -65,7 +65,7 @@
     out for this keyword.
 - title: Basic Types
   code: >-
-    https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20let%20x%20%3D%2012%3B%20%2F%2F%20by%20default%20this%20is%20i32%0A%20%20%20%20let%20a%20%3D%2012u8%3B%0A%20%20%20%20let%20b%20%3D%204.3%3B%20%2F%2F%20by%20default%20this%20is%20f64%0A%20%20%20%20let%20c%20%3D%204.3f32%3B%0A%20%20%20%20let%20bv%20%3D%20true%3B%0A%20%20%20%20let%20t%20%3D%20(13%2C%20false)%3B%0A%20%20%20%20let%20sentence%20%3D%20%22hello%20world!%22%3B%0A%20%20%20%20println!(%0A%20%20%20%20%20%20%20%20%22%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20x%2C%20a%2C%20b%2C%20c%2C%20bv%2C%20t.0%2C%20t.1%2C%20sentence%0A%20%20%20%20)%3B%0A%7D%0A
+    https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn+main%28%29+%7B%0A++++let+x+%3D+12%3B+%2F%2F+by+default+this+is+i32%0A++++let+a+%3D+12u8%3B%0A++++let+b+%3D+4.3%3B+%2F%2F+by+default+this+is+f64%0A++++let+c+%3D+4.3f32%3B%0A++++let+d+%3D+%27r%27%3B+%2F%2F+unicode+character%0A++++let+ferris+%3D+%27%F0%9F%A6%80%27%3B+%2F%2F+also+a+unicode+character%0A++++let+bv+%3D+true%3B%0A++++let+t+%3D+%2813%2C+false%29%3B%0A++++let+sentence+%3D+%22hello+world%21%22%3B%0A++++println%21%28%0A++++++++%22%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D%22%2C%0A++++++++x%2C+a%2C+b%2C+c%2C+d%2C+ferris%2C+bv%2C+t.0%2C+t.1%2C+sentence%0A++++%29%3B%0A%7D%0A
   content_markdown: >
     Rust has a variety of familiar types:
 
@@ -82,6 +82,8 @@
     and sizes of things in memory
 
     * floating point - `f32` `f64`
+
+    * characters - `char` for representing a single Unicode character
 
     * tuple - `(value, value, ...)` for passing fixed sequences of values on the
     stack

--- a/lessons/ro/chapter_1.yaml
+++ b/lessons/ro/chapter_1.yaml
@@ -66,7 +66,7 @@
     atenți la acest cuvânt cheie.
 - title: Tipuri de date de bază
   code: >-
-    https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn%20main()%20%7B%0A%20%20%20%20let%20x%20%3D%2012%3B%20%2F%2F%20acesta%20este%20un%20i32%20%C3%AEn%20mod%20implicit%0A%20%20%20%20let%20a%20%3D%2012u8%3B%0A%20%20%20%20let%20b%20%3D%204.3%3B%20%2F%2F%20acesta%20este%20un%20f64%20%C3%AEn%20mod%20implicit%0A%20%20%20%20let%20c%20%3D%204.3f32%3B%0A%20%20%20%20let%20bv%20%3D%20true%3B%0A%20%20%20%20let%20t%20%3D%20(13%2C%20false)%3B%0A%20%20%20%20let%20sentence%20%3D%20%22hello%20world!%22%3B%0A%20%20%20%20println!(%0A%20%20%20%20%20%20%20%20%22%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%20%7B%7D%22%2C%0A%20%20%20%20%20%20%20%20x%2C%20a%2C%20b%2C%20c%2C%20bv%2C%20t.0%2C%20t.1%2C%20sentence%0A%20%20%20%20)%3B%0A%7D%0A
+    https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=fn+main%28%29+%7B%0A++++let+x+%3D+12%3B+%2F%2F+acesta+este+un+i32+%C3%AEn+mod+implicit%0A++++let+a+%3D+12u8%3B%0A++++let+b+%3D+4.3%3B+%2F%2F+acesta+este+un+f64+%C3%AEn+mod+implicit%0A++++let+c+%3D+4.3f32%3B%0A++++let+d+%3D+%27r%27%3B+%2F%2F+caracter+unicode%0A++++let+ferris+%3D+%27%F0%9F%A6%80%27%3B+%2F%2F+tot+un+caracter+unicode%0A++++let+bv+%3D+true%3B%0A++++let+t+%3D+%2813%2C+false%29%3B%0A++++let+sentence+%3D+%22hello+world%21%22%3B%0A++++println%21%28%0A++++++++%22%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D+%7B%7D%22%2C%0A++++++++x%2C+a%2C+b%2C+c%2C+d%2C+ferris%2C+bv%2C+t.0%2C+t.1%2C+sentence%0A++++%29%3B%0A%7D%0A
   content_markdown: >
     Rust are o varietate de tipuri de date familiare dumneavoastră:
 
@@ -83,6 +83,8 @@
     și dimensiunea datelor în memorie
 
     * numere cu virgulă mobilă - `f32` `f64` pentru a reprezenta numere reale
+
+    * caractere - `char` pentru reprezentarea unui singur caracter Unicode
 
     * tuplu - `(valoare, valoare, ...)` pentru trecerea unor secvențe fixe de valori pe stivă
 


### PR DESCRIPTION
In chapter 1 of Tour of Rust, the char type is not mentioned in the Basic Types lesson. This issue has also been noticed in the following open issue: https://github.com/richardanaya/tour_of_rust/issues/420

The changes include adding the text explanation of `char` type use and updating the code example for both English and Romanian versions.