### PR TITLE
Updated Chapter 5: It was wrong explanation and I update it.

### DIFF
--- a/lessons/en/chapter_5.yaml
+++ b/lessons/en/chapter_5.yaml
@@ -29,8 +29,7 @@
   code: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&code=struct%20Foo%20%7B%0A%20%20%20%20x%3A%20i32%2C%0A%7D%0A%0Afn%20main()%20%7B%0A%20%20%20%20let%20foo_a%20%3D%20Foo%20%7B%20x%3A%2042%20%7D%3B%0A%20%20%20%20let%20foo_b%20%3D%20Foo%20%7B%20x%3A%2013%20%7D%3B%0A%0A%20%20%20%20println!(%22%7B%7D%22%2C%20foo_a.x)%3B%0A%0A%20%20%20%20println!(%22%7B%7D%22%2C%20foo_b.x)%3B%0A%20%20%20%20%2F%2F%20foo_b%20is%20dropped%20here%20%0A%20%20%20%20%2F%2F%20foo_a%20is%20dropped%20here%0A%7D%0A
 - title: Dropping is Hierarchical
   content_markdown: >
-    When a struct is dropped, the struct itself is dropped first, then its
-    children are dropped individually, and so on.
+    When a struct is dropped, the fields (children) are always dropped first, followed by the struct itself.
 
 
     Memory Details:


### PR DESCRIPTION
I corrected the explanations in chapter 5, under "Dropping is Hierarchical" because it was defined incorrectly.
More precisely, it was written "When a struct is dropped, the struct itself is dropped first, then its children are dropped individually, and so on." and I replaced it with "When a struct is dropped, the fields (children) are always dropped first, followed by the struct itself."